### PR TITLE
Add iguana port and make cinatra depend on it

### DIFF
--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -7,24 +7,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH IGUANA_SOURCE_PATH
-    REPO qicosmos/iguana
-    REF 1.0.9
-    SHA512 278d96bc3586104904c91bd62c5579b1db6a844ab5ef64ba3853f55bd04852cf7c035e4c88211bbab3348fba662edab5e6fd1df0d113d41cfed7b455467f9fb3
-    HEAD_REF master
-)
-
 # Install Cinatra’s headers
 file(INSTALL
     "${SOURCE_PATH}/include/cinatra"
     "${SOURCE_PATH}/include/cinatra.hpp"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
-)
-
-# Install Iguana’s headers
-file(INSTALL
-    "${IGUANA_SOURCE_PATH}/iguana"
     DESTINATION "${CURRENT_PACKAGES_DIR}/include"
 )
 

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cinatra",
   "version": "0.9.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
   "license": "MIT",
@@ -9,6 +9,7 @@
   "dependencies": [
     "asio",
     "async-simple",
+    "iguana",
     "tanakh-cmdline"
   ]
 }

--- a/ports/iguana/portfile.cmake
+++ b/ports/iguana/portfile.cmake
@@ -1,0 +1,15 @@
+set(VCPKG_BUILD_TYPE "release") # header-only port
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO qicosmos/iguana
+    REF 1.0.9
+    SHA512 278d96bc3586104904c91bd62c5579b1db6a844ab5ef64ba3853f55bd04852cf7c035e4c88211bbab3348fba662edab5e6fd1df0d113d41cfed7b455467f9fb3
+    HEAD_REF master
+)
+
+file(INSTALL
+    "${SOURCE_PATH}/iguana"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/iguana/vcpkg.json
+++ b/ports/iguana/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "iguana",
+  "version": "1.0.9",
+  "description": "Header-only C++ serialization library used by Cinatra.",
+  "homepage": "https://github.com/qicosmos/iguana",
+  "license": "Apache-2.0"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1690,7 +1690,7 @@
     },
     "cinatra": {
       "baseline": "0.9.5",
-      "port-version": 1
+      "port-version": 2
     },
     "cista": {
       "baseline": "0.15",
@@ -3755,6 +3755,10 @@
     "igloo": {
       "baseline": "1.1.1",
       "port-version": 2
+    },
+    "iguana": {
+      "baseline": "1.0.9",
+      "port-version": 0
     },
     "ignition-modularscripts": {
       "baseline": "2025-02-27",

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0ee24e6234ccfe3134daabf139fbf3ec237c9b47",
+      "version": "0.9.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "5f317d4becacd1b192bf6a4a1309ccb613ba44c0",
       "version": "0.9.5",
       "port-version": 1

--- a/versions/i-/iguana.json
+++ b/versions/i-/iguana.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "344fa214dfb1eff323ce30134587508f107a79b9",
+      "version": "1.0.9",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add new `iguana` port for the header-only serialization library
- make `cinatra` depend on the new port
- update versions and baseline

## Testing
- `./vcpkg format-manifest --all`
- `./vcpkg x-add-version --all --skip-formatting-check`


------
https://chatgpt.com/codex/tasks/task_e_683f3c1a83d0832bb1f8b26c8a0bc8b2